### PR TITLE
Update Dragen 4.4.4 workflow object used

### DIFF
--- a/infrastructure/stage/constants.ts
+++ b/infrastructure/stage/constants.ts
@@ -38,11 +38,12 @@ export const CURRENT_WORKFLOW_OBJECTS_BY_WORKFLOW_NAME: Record<StageName, Workfl
     },
     // DNA
     dragenWgtsDna: {
+      // https://github.com/umccr/cwl-ica/releases/tag/dragen-wgts-dna-pipeline%2F4.4.4__20251102002321
       name: 'dragen-wgts-dna',
       version: '4.4.4',
-      codeVersion: 'e365e71',
+      codeVersion: '677f34a',
       executionEngine: 'ICA',
-      executionEnginePipelineId: '76a85933-4656-4188-bd0a-9ac006809dc6',
+      executionEnginePipelineId: 'd43ef483-fdef-4dc3-8dac-85165c7f4d2e',
       validationState: 'VALIDATED',
     },
     arribaWgtsRna: {
@@ -131,11 +132,12 @@ export const CURRENT_WORKFLOW_OBJECTS_BY_WORKFLOW_NAME: Record<StageName, Workfl
     },
     // DNA
     dragenWgtsDna: {
+      // https://github.com/umccr/cwl-ica/releases/tag/dragen-wgts-dna-pipeline%2F4.4.4__20251102002321
       name: 'dragen-wgts-dna',
       version: '4.4.4',
-      codeVersion: 'e365e71',
+      codeVersion: '677f34a',
       executionEngine: 'ICA',
-      executionEnginePipelineId: '76a85933-4656-4188-bd0a-9ac006809dc6',
+      executionEnginePipelineId: 'd43ef483-fdef-4dc3-8dac-85165c7f4d2e',
       validationState: 'VALIDATED',
     },
     arribaWgtsRna: {
@@ -224,11 +226,12 @@ export const CURRENT_WORKFLOW_OBJECTS_BY_WORKFLOW_NAME: Record<StageName, Workfl
     },
     // DNA
     dragenWgtsDna: {
+      // https://github.com/umccr/cwl-ica/releases/tag/dragen-wgts-dna-pipeline%2F4.4.4__20251102002321
       name: 'dragen-wgts-dna',
       version: '4.4.4',
-      codeVersion: 'e365e71',
+      codeVersion: '677f34a',
       executionEngine: 'ICA',
-      executionEnginePipelineId: '76a85933-4656-4188-bd0a-9ac006809dc6',
+      executionEnginePipelineId: 'd43ef483-fdef-4dc3-8dac-85165c7f4d2e',
       validationState: 'VALIDATED',
     },
     arribaWgtsRna: {

--- a/infrastructure/stage/interfaces.ts
+++ b/infrastructure/stage/interfaces.ts
@@ -141,12 +141,12 @@ export type PierianDxTso500CtdnaWorkflowObjectType = Workflow & {
 export type DragenWgtsDnaWorkflowObjectType = Workflow &
   (
     | {
-        // https://github.com/umccr/cwl-ica/releases/tag/dragen-wgts-dna-pipeline%2F4.4.4__20251015010222
+        // https://github.com/umccr/cwl-ica/releases/tag/dragen-wgts-dna-pipeline%2F4.4.4__20251102002321
         name: 'dragen-wgts-dna';
         version: '4.4.4';
-        codeVersion: 'e365e71';
+        codeVersion: '677f34a';
         executionEngine: 'ICA';
-        executionEnginePipelineId: '76a85933-4656-4188-bd0a-9ac006809dc6';
+        executionEnginePipelineId: 'd43ef483-fdef-4dc3-8dac-85165c7f4d2e';
         validationState: 'VALIDATED';
       }
     // https://github.com/umccr/cwl-ica/releases/tag/dragen-wgts-dna-pipeline%2F4.4.6__20251030232217


### PR DESCRIPTION
Dragen 4.4.4 version was the same as the broken one last week. Updated version in interfaces, and id used in dev/stg and prod

- [x] Rebased off #25, so need to wait for that one to be merged before merging this one.