### PR TITLE
Filter out libraries without readsets

### DIFF
--- a/app/lambdas/make_bclconvert_interop_qc_event_py/make_bclconvert_interop_qc_event.py
+++ b/app/lambdas/make_bclconvert_interop_qc_event_py/make_bclconvert_interop_qc_event.py
@@ -106,18 +106,3 @@ def handler(event, context):
             libraries_list
         )
     }
-
-# if __name__ == "__main__":
-#     import json
-#     print(
-#         json.dumps(
-#             handler(
-#                 {
-#                     "libraryIdList": [
-#                         "L2401527"
-#                     ]
-#                 },
-#                 None
-#             ),
-#             indent=4
-#     ))

--- a/app/layers/analysis_tool_kit/src/analysis_tool_kit/analysis_helpers.py
+++ b/app/layers/analysis_tool_kit/src/analysis_tool_kit/analysis_helpers.py
@@ -57,6 +57,25 @@ def library_to_event_library(library: Library) -> EventLibrary:
     }
 
 
+def get_libraries_with_readsets(libraries: List[Library]) -> List[Library]:
+    """
+    Get the libraries that have readsets
+    :param libraries:
+    :return:
+    """
+    # Get all libraries with readsets
+    libraries_with_readsets = list(map(
+        library_to_event_library,
+        libraries
+    ))
+
+    # Drop libraries without readsets
+    return list(filter(
+        lambda library_iter_: len(library_iter_['readsets']) > 0,
+        libraries_with_readsets
+    ))
+
+
 def get_existing_workflow_runs(
     workflow_name: str,
     workflow_version: str,
@@ -135,8 +154,5 @@ def add_workflow_draft_event_detail(
         "workflow": workflow,
         "workflowRunName": workflow_run_name,
         "portalRunId": portal_run_id,
-        "libraries": list(map(
-            library_to_event_library,
-            libraries
-        ))
+        "libraries": get_libraries_with_readsets(libraries)
     }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@aws-cdk/aws-lambda-python-alpha": "2.231.0-alpha.0",
-    "@orcabus/platform-cdk-constructs": "0.0.99",
+    "@orcabus/platform-cdk-constructs": "0.0.103",
     "aws-cdk-lib": "^2.231.0",
     "constructs": "^10.4.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 2.231.0-alpha.0
         version: 2.231.0-alpha.0(aws-cdk-lib@2.231.0(constructs@10.4.3))(constructs@10.4.3)
       '@orcabus/platform-cdk-constructs':
-        specifier: 0.0.99
-        version: 0.0.99(@aws-cdk/aws-lambda-python-alpha@2.231.0-alpha.0(aws-cdk-lib@2.231.0(constructs@10.4.3))(constructs@10.4.3))(aws-cdk-lib@2.231.0(constructs@10.4.3))(constructs@10.4.3)
+        specifier: 0.0.103
+        version: 0.0.103(@aws-cdk/aws-lambda-python-alpha@2.231.0-alpha.0(aws-cdk-lib@2.231.0(constructs@10.4.3))(constructs@10.4.3))(aws-cdk-lib@2.231.0(constructs@10.4.3))(constructs@10.4.3)
       aws-cdk-lib:
         specifier: ^2.231.0
         version: 2.231.0(constructs@10.4.3)
@@ -402,8 +402,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@orcabus/platform-cdk-constructs@0.0.99':
-    resolution: {integrity: sha512-GDq6VfXf+xb5KnZo7MvY1M7P5PqQgEx18F+pZwfaD/KRMHVToSXPeKuqIE9LZEfTh5FY3WJxE83I6lycdghPQw==}
+  '@orcabus/platform-cdk-constructs@0.0.103':
+    resolution: {integrity: sha512-afC17fA5ytWMG23R/WZ7UhBE0SLyuIi+aZVFXcuaw27CXiwXtWK0Z8A9b3+ItVxybxleZETaIZAwhCK88+xZsw==}
     peerDependencies:
       '@aws-cdk/aws-lambda-python-alpha': ^2.213.0-alpha.0
       aws-cdk-lib: ^2.213.0
@@ -2137,7 +2137,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@orcabus/platform-cdk-constructs@0.0.99(@aws-cdk/aws-lambda-python-alpha@2.231.0-alpha.0(aws-cdk-lib@2.231.0(constructs@10.4.3))(constructs@10.4.3))(aws-cdk-lib@2.231.0(constructs@10.4.3))(constructs@10.4.3)':
+  '@orcabus/platform-cdk-constructs@0.0.103(@aws-cdk/aws-lambda-python-alpha@2.231.0-alpha.0(aws-cdk-lib@2.231.0(constructs@10.4.3))(constructs@10.4.3))(aws-cdk-lib@2.231.0(constructs@10.4.3))(constructs@10.4.3)':
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha': 2.231.0-alpha.0(aws-cdk-lib@2.231.0(constructs@10.4.3))(constructs@10.4.3)
       aws-cdk-lib: 2.231.0(constructs@10.4.3)


### PR DESCRIPTION
Upgrade platform cdk constructs to latest version

Filter to library ids to only those that contain actual readsets. 