### PR TITLE
Ensure skip logic considers all DNA/RNA libs

### DIFF
--- a/app/lambdas/make_wgts_post_analysis_events_list_py/make_wgts_post_analysis_events_list.py
+++ b/app/lambdas/make_wgts_post_analysis_events_list_py/make_wgts_post_analysis_events_list.py
@@ -177,17 +177,16 @@ def handler(event, context):
 
     # If there are no tumor libraries and no normal libraries for this
     # subject on this run, return an empty list
-    if len(tumor_dna_libraries) == 0 and len(normal_dna_libraries) == 0:
-        return {
-            "eventDetailList": list(filter(
-                lambda event_iter_: event_iter_ is not None,
-                events_list
-            ))
-        }
-
-    # Check if there are not any tumor WTS libraries for this subject
-    if len(tumor_rna_libraries) == 0:
-        # If there are no tumor WGS libraries for this subject on this run
+    if (
+            # No DNA libraries
+            (
+                len(tumor_dna_libraries) == 0 and len(normal_dna_libraries) == 0
+            ) and
+            # No RNA libraries
+            (
+                len(tumor_rna_libraries) == 0
+            )
+    ):
         return {
             "eventDetailList": list(filter(
                 lambda event_iter_: event_iter_ is not None,


### PR DESCRIPTION
----- app/lambdas/make_wgts_post_analysis_events_list_py
*   Correct a bug where the lambda could return an empty event list prematurely.
*   The previous logic might skip processing if only DNA libraries were absent, or if only RNA libraries were absent.
*   Update the conditional check to only skip if *both* DNA and RNA libraries are entirely missing for the subject.

Resolves #53 