### PR TITLE
Process only clinical and research samples

### DIFF
--- a/app/lambdas/make_wgs_analysis_events_list_py/make_wgs_analysis_events_list.py
+++ b/app/lambdas/make_wgs_analysis_events_list_py/make_wgs_analysis_events_list.py
@@ -285,7 +285,8 @@ def handler(event, context):
         lambda library_iter_: (
             library_iter_['subject']['orcabusId'] == subject_orcabus_id and
             library_iter_['type'] == 'WGS' and
-            get_libraries_with_readsets([library_iter_])
+            get_libraries_with_readsets([library_iter_]) and
+            library_iter_['workflow'] in WGTS_WORKFLOW_NAMES
         ),
         sorted(
             get_all_libraries(),

--- a/app/lambdas/make_wgs_analysis_events_list_py/make_wgs_analysis_events_list.py
+++ b/app/lambdas/make_wgs_analysis_events_list_py/make_wgs_analysis_events_list.py
@@ -54,6 +54,12 @@ GERMLINE_ONLY_WORKFLOW_NAMES = [
     'germline',
 ]
 
+# 'workflow' attribute for tumor library must match one of the following
+WGTS_WORKFLOW_NAMES = [
+    'clinical',
+    'research'
+]
+
 # Set logger
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -208,6 +214,12 @@ def handler(event, context):
         libraries_list
     ))
 
+    # Filter tumor libraries to only those with a matching 'workflow' value
+    tumor_libraries = list(filter(
+        lambda library_iter_: library_iter_['workflow'] in WGTS_WORKFLOW_NAMES,
+        tumor_libraries
+    ))
+
     # Check for negative control
     negative_control_libraries = list(filter(
         lambda library_iter_: (
@@ -216,8 +228,8 @@ def handler(event, context):
         libraries_list
     ))
 
+    # Negative control libraries should only go through dragen
     if len(negative_control_libraries) > 0:
-        # Negative control libraries should only go through dragen
         for ntc_library in negative_control_libraries:
             events_list.extend([
                 add_dragen_wgts_dna_draft_event(

--- a/app/lambdas/make_wgts_post_analysis_events_list_py/make_wgts_post_analysis_events_list.py
+++ b/app/lambdas/make_wgts_post_analysis_events_list_py/make_wgts_post_analysis_events_list.py
@@ -223,7 +223,8 @@ def handler(event, context):
             library_iter_['subject']['orcabusId'] == subject_orcabus_id and
             library_iter_['type'] in ['WGS', 'WTS'] and
             library_iter_['phenotype'] in ['tumor', 'normal'] and
-            get_libraries_with_readsets([library_iter_])
+            get_libraries_with_readsets([library_iter_]) and
+            library_iter_['workflow'] in WGTS_WORKFLOW_NAMES
         ),
         sorted(
             get_all_libraries(),

--- a/app/lambdas/make_wgts_post_analysis_events_list_py/make_wgts_post_analysis_events_list.py
+++ b/app/lambdas/make_wgts_post_analysis_events_list_py/make_wgts_post_analysis_events_list.py
@@ -44,6 +44,13 @@ WORKFLOW_OBJECTS_DICT: Dict[WorkflowName, Workflow] = {
 # Draft status
 DRAFT_STATUS = "DRAFT"
 
+# Only tumor libraries with a workflow value
+# should go through the wgts dna/rna pipeline
+WGTS_WORKFLOW_NAMES = [
+    'clinical',
+    'research'
+]
+
 # Set logger
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -167,6 +174,16 @@ def handler(event, context):
             library_iter_['type'] == 'WTS'
         ),
         libraries_list
+    ))
+
+    # Filter tumor libraries to only those with a matching 'workflow' value
+    tumor_dna_libraries = list(filter(
+        lambda library_iter_: library_iter_['workflow'] in WGTS_WORKFLOW_NAMES,
+        tumor_dna_libraries
+    ))
+    tumor_rna_libraries = list(filter(
+        lambda library_iter_: library_iter_['workflow'] in WGTS_WORKFLOW_NAMES,
+        tumor_rna_libraries
     ))
 
     # We want to remove these from consideration

--- a/app/lambdas/make_wts_analysis_events_list_py/make_wts_analysis_events_list.py
+++ b/app/lambdas/make_wts_analysis_events_list_py/make_wts_analysis_events_list.py
@@ -35,6 +35,13 @@ DRAFT_STATUS = "DRAFT"
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Only tumor libraries with a workflow value
+# should go through the wgts rna pipeline
+WGTS_WORKFLOW_NAMES = [
+    'clinical',
+    'research'
+]
+
 
 def add_dragen_wgts_rna_draft_event(
         libraries: List[Library],
@@ -150,7 +157,9 @@ def handler(event, context):
 
     # Filter to WTS libraries only
     libraries_list = list(filter(
-        lambda library_iter_: library_iter_['type'] == 'WTS',
+        lambda library_iter_: (
+            library_iter_['type'] == 'WTS'
+        ),
         libraries_list
     ))
 
@@ -173,6 +182,12 @@ def handler(event, context):
     tumor_libraries = list(filter(
         lambda library_iter_: library_iter_['phenotype'] == 'tumor',
         libraries_list
+    ))
+
+    # Filter by workflow type
+    tumor_libraries = list(filter(
+        lambda library_iter_: library_iter_['workflow'] in WGTS_WORKFLOW_NAMES,
+        tumor_libraries
     ))
 
     for library_iter in tumor_libraries:


### PR DESCRIPTION
If the tumor library 'workflow' attribute is not one of clinical or research it should not be automatically processed