### PR TITLE
Update sash default version to 0.6.4

### DIFF
--- a/infrastructure/stage/constants.ts
+++ b/infrastructure/stage/constants.ts
@@ -64,10 +64,10 @@ export const CURRENT_WORKFLOW_OBJECTS_BY_WORKFLOW_NAME: Record<StageName, Workfl
     },
     sash: {
       name: 'sash',
-      version: '0.6.3',
-      codeVersion: '89a7a21',
+      version: '0.6.4',
+      codeVersion: '4946aa8',
       executionEngine: 'ICA',
-      executionEnginePipelineId: '5b4060de-5e43-4aa6-b408-f51537d43c65',
+      executionEnginePipelineId: '51f0d1dc-be92-4a5e-9a8a-ad8d44a6431c',
       validationState: 'VALIDATED',
     },
     // RNA
@@ -157,10 +157,10 @@ export const CURRENT_WORKFLOW_OBJECTS_BY_WORKFLOW_NAME: Record<StageName, Workfl
     },
     sash: {
       name: 'sash',
-      version: '0.6.3',
-      codeVersion: '89a7a21',
+      version: '0.6.4',
+      codeVersion: '4946aa8',
       executionEngine: 'ICA',
-      executionEnginePipelineId: '5b4060de-5e43-4aa6-b408-f51537d43c65',
+      executionEnginePipelineId: '51f0d1dc-be92-4a5e-9a8a-ad8d44a6431c',
       validationState: 'VALIDATED',
     },
     // RNA
@@ -250,10 +250,10 @@ export const CURRENT_WORKFLOW_OBJECTS_BY_WORKFLOW_NAME: Record<StageName, Workfl
     },
     sash: {
       name: 'sash',
-      version: '0.6.3',
-      codeVersion: '89a7a21',
+      version: '0.6.4',
+      codeVersion: '4946aa8',
       executionEngine: 'ICA',
-      executionEnginePipelineId: '5b4060de-5e43-4aa6-b408-f51537d43c65',
+      executionEnginePipelineId: '51f0d1dc-be92-4a5e-9a8a-ad8d44a6431c',
       validationState: 'VALIDATED',
     },
     // RNA


### PR DESCRIPTION
## Summary

- Bumps sash from `0.6.3` (pipeline `5b4060de`) to `0.6.4` (pipeline `51f0d1dc`) for BETA, GAMMA, and PROD
- The `0.6.4` interface was already defined in `interfaces.ts`; this PR makes it the active default across all stages

link PR
- https://github.com/OrcaBus/service-sash-pipeline-manager/pull/52